### PR TITLE
fixed a bug that updated variance accidentaly

### DIFF
--- a/multiarow/arow.py
+++ b/multiarow/arow.py
@@ -58,7 +58,8 @@ class AROW(object):
                 y = 1 if c < 0 else 0
             else:
                 y = -1 if c >= 0 else 0
-            self._update(l, x, y, self.w[l], self.v[l])
+            if y != 0:
+                self._update(l, x, y, self.w[l], self.v[l])
 
     def classify(self, x):
         '''Perfom classification based on the current weights


### PR DESCRIPTION
In case prediction is correct (y == 0), there is no need to update w and v. w is fine with the current implementation since y cancels it, but v isn't.
